### PR TITLE
add link to HF version of dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 This repository contains the dataset from our NAACL 2024 paper "Improving Adversarial Data Collection by Supporting Annotators: Lessons from GAHD, a German Hate Speech Dataset".
+You can also find this dataset on the [Hugging Face Hub](https://huggingface.co/datasets/davanstrien/gahd).
 
 `gahd.csv` contains the following columns:
 - `gahd_id`: unique identifier of the entry


### PR DESCRIPTION
Great dataset, I thought it was nice to have a version on the HF Hub to make it easier for people to use so I uploaded a copy there. https://huggingface.co/datasets/davanstrien/gahd. Happy to migrate the dataset to your HF user/org account :) 